### PR TITLE
unifing speed for serial port in nexConfig.h and add fast timeout mode to be used in case of connections over 115200 baud

### DIFF
--- a/NexConfig.h
+++ b/NexConfig.h
@@ -28,6 +28,28 @@
 */
 // #define STD_SUPPORT
 
+/**
+ * Define serial communication baud
+ * 
+*/
+#define STD_SERIAL_BAUD 9600
+
+/**
+ * Define standard or fast timeout
+ * 
+*/
+//#define NEX_TIMEOUT_STANDARD
+#define NEX_TIMEOUT_FAST
+
+#ifdef NEX_TIMEOUT_FAST
+#define NEX_TIMEOUT_CONNECT   10
+#define NEX_TIMEOUT_COMMAND   10
+#define NEX_TIMEOUT_RETURN    10
+#else
+#define NEX_TIMEOUT_CONNECT 1000
+#define NEX_TIMEOUT_COMMAND  200
+#define NEX_TIMEOUT_RETURN   100
+#endif
 /** 
  * Define NEX_DEBUG_SERIAL_ENABLE to enable debug serial. 
  * Comment it to disable debug serial. 

--- a/NexHardware.cpp
+++ b/NexHardware.cpp
@@ -382,8 +382,8 @@ bool nexInit(const uint32_t baud)
     bool ret1 = false;
     bool ret2 = false;
 
-    nexSerial.begin(9600); // default baud, it is recommended that do not change defaul baud on Nextion, because it can forgot it on re-start
-    if(baud!=9600)
+    nexSerial.begin(STD_SERIAL_BAUD); // default baud, it is recommended that do not change defaul baud on Nextion, because it can forgot it on re-start
+    if(baud!=STD_SERIAL_BAUD)
     {
         char cmd[14];
         sprintf(cmd,"baud=%i",baud);
@@ -399,7 +399,7 @@ bool nexInit(const uint32_t baud)
     ret2 = recvRetCommandFinished();
     sendCommand("connect");
     String str;
-    recvRetString(str,1000);
+    recvRetString(str,NEX_TIMEOUT_CONNECT);
     dbSerialPrintln(str);
 
     return ret2;

--- a/NexHardware.h
+++ b/NexHardware.h
@@ -102,10 +102,10 @@ extern void (*startSdUpgradeCallback)();
 /**
  * @}
  */
-bool recvRetNumber(uint32_t *number, size_t timeout = 100);
-bool recvRetNumber(int32_t *number, size_t timeout = 100);
-bool recvRetString(String &str, size_t timeout = 100);
-bool recvRetString(char *buffer, uint16_t &len, size_t timeout = 100);
+bool recvRetNumber(uint32_t *number, size_t timeout = NEX_TIMEOUT_RETURN);
+bool recvRetNumber(int32_t *number, size_t timeout = NEX_TIMEOUT_RETURN);
+bool recvRetString(String &str, size_t timeout = NEX_TIMEOUT_RETURN);
+bool recvRetString(char *buffer, uint16_t &len, size_t timeout = NEX_TIMEOUT_RETURN);
 
 /* Send Command to device
 *
@@ -165,7 +165,7 @@ bool recvCommand(const uint8_t command, size_t timeout);
  * @retval false - failed. 
  *
  */
-bool recvRetCommandFinished(size_t timeout = 200);
+bool recvRetCommandFinished(size_t timeout = NEX_TIMEOUT_COMMAND);
 
 /*
  * Transpared data mode setup successfully 


### PR DESCRIPTION
Hi,

I've moved all serial port speed in a single definition in nexConfig.h

in addition, I've add a #define flag to use different timeout in case of serial connections over (or equal) 115200 baud

thanks,
Francesco